### PR TITLE
API for å hente Saksnummer

### DIFF
--- a/app/src/main/kotlin/no/nav/punsjbolle/ApplicationContext.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/ApplicationContext.kt
@@ -12,6 +12,7 @@ import no.nav.punsjbolle.infotrygd.InfotrygdClient
 import no.nav.punsjbolle.joark.SafClient
 import no.nav.punsjbolle.k9sak.K9SakClient
 import no.nav.punsjbolle.ruting.RutingService
+import no.nav.punsjbolle.sak.SakClient
 import java.net.URI
 
 internal class ApplicationContext(
@@ -19,6 +20,7 @@ internal class ApplicationContext(
     internal val healthChecks: Set<HealthCheck>,
     internal val accessTokenClient: AccessTokenClient,
     internal val k9SakClient: K9SakClient,
+    internal val sakClient: SakClient,
     internal val safClient: SafClient,
     internal val infotrygdClient: InfotrygdClient,
     internal val rutingService: RutingService,
@@ -33,6 +35,7 @@ internal class ApplicationContext(
         var env: Environment? = null,
         var accessTokenClient: AccessTokenClient? = null,
         var k9SakClient: K9SakClient? = null,
+        var sakClient: SakClient? = null,
         var safClient: SafClient? = null,
         var infotrygdClient: InfotrygdClient? = null,
         var rutingService: RutingService? = null,
@@ -54,6 +57,12 @@ internal class ApplicationContext(
                 scopes = benyttetEnv.hentRequiredEnv("K9_SAK_SCOPES").csvTilSet(),
             )
 
+            val benyttetSakClient = sakClient ?: SakClient(
+                baseUrl = URI(benyttetEnv.hentRequiredEnv("SAK_BASE_URL")),
+                accessTokenClient = benyttetAccessTokenClient,
+                scopes = benyttetEnv.hentRequiredEnv("SAK_SCOPES").csvTilSet()
+            )
+
             val benyttetSafClient = safClient ?: SafClient(
                 baseUrl = URI(benyttetEnv.hentRequiredEnv("SAF_BASE_URL")),
                 accessTokenClient = benyttetAccessTokenClient,
@@ -72,13 +81,14 @@ internal class ApplicationContext(
                 k9SakClient = benyttetK9SakClient,
                 safClient = benyttetSafClient,
                 infotrygdClient = benyttetInfotrygdClient,
-                healthChecks = setOf(benyttetK9SakClient, benyttetSafClient, benyttetInfotrygdClient),
+                healthChecks = setOf(benyttetK9SakClient, benyttetSafClient, benyttetInfotrygdClient, benyttetSakClient),
                 onStart = onStart,
                 onStop = onStop,
                 rutingService = rutingService ?: RutingService(
                     k9SakClient = benyttetK9SakClient,
                     infotrygdClient = benyttetInfotrygdClient
-                )
+                ),
+                sakClient = benyttetSakClient
             )
         }
     }

--- a/app/src/main/kotlin/no/nav/punsjbolle/KtorApplication.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/KtorApplication.kt
@@ -5,6 +5,7 @@ import io.ktor.features.*
 import io.ktor.jackson.*
 import io.ktor.routing.*
 import no.nav.helse.dusseldorf.ktor.health.*
+import no.nav.punsjbolle.api.SaksnummerApi
 
 internal fun Application.punsjbolle(
     applicationContext: ApplicationContext = ApplicationContext.Builder().build()) {
@@ -32,6 +33,13 @@ internal fun Application.punsjbolle(
 
     routing {
         HealthRoute(healthService = healthService)
+        route("/api") {
+            SaksnummerApi(
+                rutingService = applicationContext.rutingService,
+                safClient = applicationContext.safClient,
+                k9SakClient = applicationContext.k9SakClient
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/no/nav/punsjbolle/KtorApplication.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/KtorApplication.kt
@@ -1,17 +1,26 @@
 package no.nav.punsjbolle
 
 import io.ktor.application.*
+import io.ktor.auth.*
 import io.ktor.features.*
 import io.ktor.jackson.*
 import io.ktor.routing.*
+import no.nav.helse.dusseldorf.ktor.auth.*
+import no.nav.helse.dusseldorf.ktor.core.*
 import no.nav.helse.dusseldorf.ktor.health.*
+import no.nav.k9.rapid.river.hentRequiredEnv
 import no.nav.punsjbolle.api.SaksnummerApi
+import java.net.URI
 
 internal fun Application.punsjbolle(
     applicationContext: ApplicationContext = ApplicationContext.Builder().build()) {
 
     install(ContentNegotiation) {
         jackson {}
+    }
+    install(StatusPages) {
+        AuthStatusPages()
+        DefaultStatusPages()
     }
 
     val healthService = HealthService(
@@ -26,19 +35,51 @@ internal fun Application.punsjbolle(
         })
     )
 
+    val azureV2 = Issuer(
+        issuer = applicationContext.env.hentRequiredEnv("AZURE_OPENID_CONFIG_ISSUER"),
+        jwksUri = URI(applicationContext.env.hentRequiredEnv("AZURE_OPENID_CONFIG_JWKS_URI")),
+        audience = applicationContext.env.hentRequiredEnv("AZURE_APP_CLIENT_ID"),
+        alias = "azure-v2"
+    )
+
+    val issuers = mapOf(
+        azureV2.alias() to azureV2,
+    ).withoutAdditionalClaimRules()
+
+    install(Authentication) {
+        multipleJwtIssuers(
+            issuers = issuers
+        )
+    }
+
     HealthReporter(
         app = "k9-punsjbolle",
         healthService = healthService
     )
 
+    preStopOnApplicationStopPreparing(preStopActions = listOf(
+        FullførAktiveRequester(this)
+    ))
+
+    install(CallId) {
+        fromXCorrelationIdHeader()
+    }
+
+    install(CallLogging) {
+        logRequests()
+        correlationIdAndRequestIdInMdc()
+    }
+
     routing {
         HealthRoute(healthService = healthService)
-        route("/api") {
-            SaksnummerApi(
-                rutingService = applicationContext.rutingService,
-                safClient = applicationContext.safClient,
-                k9SakClient = applicationContext.k9SakClient
-            )
+        authenticate(*issuers.allIssuers()) {
+            route("/api") {
+                SaksnummerApi(
+                    rutingService = applicationContext.rutingService,
+                    safClient = applicationContext.safClient,
+                    k9SakClient = applicationContext.k9SakClient
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/no/nav/punsjbolle/KtorApplication.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/KtorApplication.kt
@@ -77,7 +77,8 @@ internal fun Application.punsjbolle(
                 SaksnummerApi(
                     rutingService = applicationContext.rutingService,
                     safClient = applicationContext.safClient,
-                    k9SakClient = applicationContext.k9SakClient
+                    k9SakClient = applicationContext.k9SakClient,
+                    sakClient = applicationContext.sakClient
                 )
             }
         }

--- a/app/src/main/kotlin/no/nav/punsjbolle/Typer.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/Typer.kt
@@ -76,6 +76,7 @@ internal data class Periode(internal val fom: LocalDate?, internal val tom: Loca
                 }
             )
         }
+        internal fun LocalDate.somPeriode() = Periode(fom = this, tom = this)
     }
 }
 

--- a/app/src/main/kotlin/no/nav/punsjbolle/Typer.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/Typer.kt
@@ -45,7 +45,7 @@ internal data class CorrelationId private constructor(private val value: String)
     override fun toString() = value
     internal companion object {
         private val Regex = "[a-zA-Z0-9_.\\-æøåÆØÅ]{5,200}".toRegex()
-        private fun String.somCorrelationId() = CorrelationId(this)
+        internal fun String.somCorrelationId() = CorrelationId(this)
         internal fun JsonMessage.correlationId() = get(Behovsformat.CorrelationId).asText().somCorrelationId()
     }
 }

--- a/app/src/main/kotlin/no/nav/punsjbolle/api/SaksnummerApi.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/api/SaksnummerApi.kt
@@ -21,12 +21,14 @@ import no.nav.punsjbolle.joark.SafClient
 import no.nav.punsjbolle.k9sak.K9SakClient
 import no.nav.punsjbolle.meldinger.HentK9SaksnummerMelding
 import no.nav.punsjbolle.ruting.RutingService
+import no.nav.punsjbolle.sak.SakClient
 import java.time.LocalDate
 
 internal fun Route.SaksnummerApi(
     rutingService: RutingService,
     safClient: SafClient,
-    k9SakClient: K9SakClient) {
+    k9SakClient: K9SakClient,
+    sakClient: SakClient) {
 
     post("/saksnummer") {
         val request = call.request()
@@ -57,7 +59,11 @@ internal fun Route.SaksnummerApi(
                         periode = fraOgMed.somPeriode()
                     )
                 )
-                // TODO: Legge til kobling mot sak
+                sakClient.forsikreSakskoblingFinnes(
+                    saksnummer = saksnummer,
+                    søker = request.søker.aktørId,
+                    correlationId = request.correlationId
+                )
                 call.respondText(
                     contentType = ContentType.Application.Json,
                     text = """{"saksnummer": "$saksnummer"}""",

--- a/app/src/main/kotlin/no/nav/punsjbolle/api/SaksnummerApi.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/api/SaksnummerApi.kt
@@ -1,0 +1,113 @@
+package no.nav.punsjbolle.api
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.punsjbolle.*
+import no.nav.punsjbolle.AktørId
+import no.nav.punsjbolle.AktørId.Companion.somAktørId
+import no.nav.punsjbolle.CorrelationId
+import no.nav.punsjbolle.CorrelationId.Companion.somCorrelationId
+import no.nav.punsjbolle.Identitetsnummer
+import no.nav.punsjbolle.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.punsjbolle.JournalpostId
+import no.nav.punsjbolle.JournalpostId.Companion.somJournalpostId
+import no.nav.punsjbolle.Søknadstype
+import no.nav.punsjbolle.api.Request.Companion.request
+import no.nav.punsjbolle.joark.SafClient
+import no.nav.punsjbolle.k9sak.K9SakClient
+import no.nav.punsjbolle.meldinger.HentK9SaksnummerMelding
+import no.nav.punsjbolle.ruting.RutingService
+import org.json.JSONObject
+import java.time.LocalDate
+
+internal fun Route.SaksnummerApi(
+    rutingService: RutingService,
+    safClient: SafClient,
+    k9SakClient: K9SakClient) {
+
+    post("/saksnummer") {
+        val request = call.request()
+
+        val fraOgMed = request.fraOgMed ?: safClient.hentJournalpost(
+            journalpostId = request.journalpostId!!,
+            correlationId = request.correlationId
+        ).opprettet.toLocalDate()
+
+        val destinasjon = rutingService.destinasjon(
+            søker = request.søker.identitetsnummer,
+            pleietrengende = request.pleietrengende?.identitetsnummer,
+            annenPart = request.annenPart?.identitetsnummer,
+            fraOgMed = fraOgMed,
+            søknadstype = request.søknadstype,
+            correlationId = request.correlationId
+        )
+
+        when (destinasjon) {
+            RutingService.Destinasjon.K9Sak -> {
+                val saksnummer = k9SakClient.hentSaksnummer(
+                    correlationId = request.correlationId,
+                    grunnlag = HentK9SaksnummerMelding.HentK9SaksnummerGrunnlag(
+                        søknadstype = request.søknadstype,
+                        søker = request.søker.aktørId,
+                        pleietrengende = request.pleietrengende?.aktørId,
+                        annenPart = request.annenPart?.aktørId,
+                        periode = Periode(fom = fraOgMed, tom = null)
+                    )
+                )
+                call.respondText(
+                    contentType = ContentType.Application.Json,
+                    text = """{"saksnummer": "$saksnummer"}""",
+                    status = HttpStatusCode.OK
+                )
+            }
+            RutingService.Destinasjon.Infotrygd -> {
+                call.respond(HttpStatusCode.Conflict)
+            }
+        }
+    }
+}
+
+internal data class Request(
+    val correlationId: CorrelationId,
+    val journalpostId: JournalpostId?,
+    val søker: Part,
+    val pleietrengende: Part?,
+    val annenPart: Part?,
+    val fraOgMed: LocalDate?,
+    val søknadstype: Søknadstype) {
+
+    init { require(journalpostId != null || fraOgMed != null) {
+        "Må sette enten journalpostId eller fraOgMed"
+    }}
+
+    internal data class Part(
+        val aktørId: AktørId,
+        val identitetsnummer: Identitetsnummer
+    )
+
+    internal companion object {
+        private fun JSONObject.stringOrNull(key: String) = when (has(key) && get(key) is String) {
+            true -> getString(key)
+            false -> null
+        }
+        private fun JSONObject.partOrNull(key: String) = kotlin.runCatching { getJSONObject(key).let { part ->
+            Part(aktørId = part.getString("aktørId").somAktørId(), identitetsnummer = part.getString("identitetsnummer").somIdentitetsnummer())
+        }}.fold(onSuccess = {it}, onFailure = {null})
+        private suspend fun ApplicationCall.json() = kotlin.runCatching { JSONObject(receiveText()) }.fold(onSuccess = {it}, onFailure = {JSONObject()})
+        internal suspend fun ApplicationCall.request() : Request {
+            val json = json()
+            return Request(
+                correlationId = request.header(HttpHeaders.XCorrelationId)?.somCorrelationId() ?: throw IllegalStateException("Mangler correlationId"),
+                journalpostId = json.stringOrNull("journalpostId")?.somJournalpostId(),
+                søknadstype = json.stringOrNull("søknadstype")?.let { Søknadstype.valueOf(it) } ?: throw IllegalStateException("Mangler søknadstype"),
+                søker = json.partOrNull("søker") ?: throw IllegalStateException("Mangler søker"),
+                pleietrengende = json.partOrNull("pleietrengende"),
+                annenPart = json.partOrNull("annenPart"),
+                fraOgMed = json.stringOrNull("fraOgMed")?.let { LocalDate.parse(it) }
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/punsjbolle/api/SaksnummerApi.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/api/SaksnummerApi.kt
@@ -6,7 +6,6 @@ import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
-import no.nav.punsjbolle.*
 import no.nav.punsjbolle.AktørId
 import no.nav.punsjbolle.AktørId.Companion.somAktørId
 import no.nav.punsjbolle.CorrelationId
@@ -15,6 +14,7 @@ import no.nav.punsjbolle.Identitetsnummer
 import no.nav.punsjbolle.Identitetsnummer.Companion.somIdentitetsnummer
 import no.nav.punsjbolle.JournalpostId
 import no.nav.punsjbolle.JournalpostId.Companion.somJournalpostId
+import no.nav.punsjbolle.Periode.Companion.somPeriode
 import no.nav.punsjbolle.Søknadstype
 import no.nav.punsjbolle.api.Request.Companion.request
 import no.nav.punsjbolle.joark.SafClient
@@ -54,9 +54,10 @@ internal fun Route.SaksnummerApi(
                         søker = request.søker.aktørId,
                         pleietrengende = request.pleietrengende?.aktørId,
                         annenPart = request.annenPart?.aktørId,
-                        periode = Periode(fom = fraOgMed, tom = null)
+                        periode = fraOgMed.somPeriode()
                     )
                 )
+                // TODO: Legge til kobling mot sak
                 call.respondText(
                     contentType = ContentType.Application.Json,
                     text = """{"saksnummer": "$saksnummer"}""",

--- a/app/src/main/kotlin/no/nav/punsjbolle/infotrygd/InfotrygdClient.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/infotrygd/InfotrygdClient.kt
@@ -34,11 +34,19 @@ internal class InfotrygdClient(
         pleietrengende: Identitetsnummer?,
         annenPart: Identitetsnummer?,
         correlationId: CorrelationId
-    ) = RutingGrunnlag(
-        søker = harSakSomSøker(søker, fraOgMed, correlationId),
-        pleietrengende = pleietrengende?.let { harSakSomPleietrengende(it, fraOgMed, correlationId) } ?: false,
-        annenPart = annenPart?.let { harSakSomSøker(it, fraOgMed, correlationId) } ?: false
-    )
+    ) : RutingGrunnlag {
+        if (harSakSomSøker(søker, fraOgMed, correlationId)) {
+            return RutingGrunnlag(søker = true)
+        }
+        if (pleietrengende?.let { harSakSomPleietrengende(it, fraOgMed, correlationId) } == true) {
+            return RutingGrunnlag(søker = false, pleietrengende = true)
+        }
+        return RutingGrunnlag(
+            søker = false,
+            pleietrengende = false,
+            annenPart = annenPart?.let { harSakSomSøker(it, fraOgMed, correlationId) } ?: false
+        )
+    }
 
     private suspend fun harSakSomSøker(
         identitetsnummer: Identitetsnummer,

--- a/app/src/main/kotlin/no/nav/punsjbolle/infotrygd/InfotrygdClient.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/infotrygd/InfotrygdClient.kt
@@ -81,7 +81,7 @@ internal class InfotrygdClient(
         }
 
         return JSONArray(response).inneholderAktuelleVedtak().also { if (it) {
-            secureLogger.info("Fant vedtk i Infotrygd som pleietrengende for Identitetsnummer=[$identitetsnummer], FraOgMed=[$fraOgMed], Response=[$response]")
+            secureLogger.info("Fant vedtak i Infotrygd som pleietrengende for Identitetsnummer=[$identitetsnummer], FraOgMed=[$fraOgMed], Response=[$response]")
         }}
     }
 
@@ -103,8 +103,8 @@ internal class InfotrygdClient(
             true -> getString(key)
             else -> null
         }
-        private fun JSONObject.hasJSONObject(key: String) = has(key) && get(key) is JSONObject
 
+        private fun JSONObject.hasJSONObject(key: String) = has(key) && get(key) is JSONObject
 
         private fun JSONObject.inneholderAktuelle(key: String) =
             getJSONArrayOrEmptyArray(key)
@@ -124,6 +124,5 @@ internal class InfotrygdClient(
             map { it as JSONObject }
             .map { it.inneholderAktuelle("vedtak") }
             .any { it }
-
     }
 }

--- a/app/src/main/kotlin/no/nav/punsjbolle/joark/SafClient.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/joark/SafClient.kt
@@ -59,7 +59,7 @@ internal class SafClient(
         return journalposter
     }
 
-    private suspend fun hentJournalpost(
+    internal suspend fun hentJournalpost(
         journalpostId: JournalpostId,
         correlationId: CorrelationId
     ): Journalpost {

--- a/app/src/main/kotlin/no/nav/punsjbolle/k9sak/K9SakClient.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/k9sak/K9SakClient.kt
@@ -115,11 +115,19 @@ internal class K9SakClient(
         fraOgMed: LocalDate,
         søknadstype: Søknadstype,
         correlationId: CorrelationId
-    ) = RutingGrunnlag(
-        søker = finnesMatchendeFagsak(søker = søker, fraOgMed = fraOgMed, correlationId = correlationId, søknadstype = søknadstype),
-        pleietrengende = pleietrengende?.let { finnesMatchendeFagsak(pleietrengende = it, fraOgMed = fraOgMed, correlationId = correlationId, søknadstype = søknadstype) } ?: false,
-        annenPart = annenPart?.let { finnesMatchendeFagsak(søker = it, fraOgMed = fraOgMed, correlationId = correlationId, søknadstype = søknadstype) } ?: false
-    )
+    ) : RutingGrunnlag {
+        if (finnesMatchendeFagsak(søker = søker, fraOgMed = fraOgMed, correlationId = correlationId, søknadstype = søknadstype)) {
+            return RutingGrunnlag(søker = true)
+        }
+        if (pleietrengende?.let { finnesMatchendeFagsak(pleietrengende = it, fraOgMed = fraOgMed, correlationId = correlationId, søknadstype = søknadstype) } == true) {
+            return RutingGrunnlag(søker = false, pleietrengende = true)
+        }
+        return RutingGrunnlag(
+            søker = false,
+            pleietrengende = false,
+            annenPart = annenPart?.let { finnesMatchendeFagsak(søker = it, fraOgMed = fraOgMed, correlationId = correlationId, søknadstype = søknadstype) } ?: false
+        )
+    }
 
     private suspend fun finnesMatchendeFagsak(
         søker: Identitetsnummer? = null,

--- a/app/src/main/kotlin/no/nav/punsjbolle/k9sak/K9SakClient.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/k9sak/K9SakClient.kt
@@ -20,7 +20,6 @@ import no.nav.punsjbolle.søknad.PunsjetSøknadMelding
 import org.intellij.lang.annotations.Language
 import org.json.JSONArray
 import org.json.JSONObject
-import org.slf4j.LoggerFactory
 import java.net.URI
 import java.time.LocalDate
 import java.util.*
@@ -160,13 +159,10 @@ internal class K9SakClient(
             "Feil fra K9Sak. URL=[$MatchFagsak], HttpStatusCode=[${httpStatusCode.value}], Response=[$response]"
         }
 
-        return response.inneholderMatchendeFagsak().also { if (it) {
-            secureLogger.info("Fant sak(er) i K9sak, Request=[${JSONObject(dto)}], Response=[$response]")
-        }}
+        return response.inneholderMatchendeFagsak()
     }
 
     internal companion object {
-        private val secureLogger = LoggerFactory.getLogger("tjenestekall")
         private const val ConsumerIdHeaderKey = "Nav-Consumer-Id"
         private const val ConsumerIdHeaderValue = "k9-punsjbolle"
         private const val CorrelationIdHeaderKey = "Nav-Callid"

--- a/app/src/main/kotlin/no/nav/punsjbolle/ruting/RutingGrunnlag.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/ruting/RutingGrunnlag.kt
@@ -4,6 +4,7 @@ internal data class RutingGrunnlag(
     internal val søker: Boolean? = null,
     internal val pleietrengende: Boolean? = null,
     internal val annenPart: Boolean? = null) {
-    init { require(søker != null || pleietrengende != null || annenPart != null) {"Minst et part må være evaluert."} }
+    private val ingenParter = søker == false && pleietrengende == false && annenPart == false
     internal val minstEnPart = søker == true || pleietrengende == true || annenPart == true
+    init { require(minstEnPart || ingenParter) {"Minst en part må være true, eller alle false. Var $this"} }
 }

--- a/app/src/main/kotlin/no/nav/punsjbolle/ruting/RutingGrunnlag.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/ruting/RutingGrunnlag.kt
@@ -1,8 +1,9 @@
 package no.nav.punsjbolle.ruting
 
-data class RutingGrunnlag(
-    internal val søker: Boolean,
-    internal val pleietrengende: Boolean,
-    internal val annenPart: Boolean) {
-    internal val minstEnPart = søker || pleietrengende || annenPart
+internal data class RutingGrunnlag(
+    internal val søker: Boolean? = null,
+    internal val pleietrengende: Boolean? = null,
+    internal val annenPart: Boolean? = null) {
+    init { require(søker != null || pleietrengende != null || annenPart != null) {"Minst et part må være evaluert."} }
+    internal val minstEnPart = søker == true || pleietrengende == true || annenPart == true
 }

--- a/app/src/main/kotlin/no/nav/punsjbolle/ruting/RutingService.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/ruting/RutingService.kt
@@ -5,6 +5,7 @@ import no.nav.punsjbolle.Identitetsnummer
 import no.nav.punsjbolle.Søknadstype
 import no.nav.punsjbolle.infotrygd.InfotrygdClient
 import no.nav.punsjbolle.k9sak.K9SakClient
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 internal class RutingService(
@@ -37,9 +38,9 @@ internal class RutingService(
         )
 
         return when {
-            k9SakGrunnlag.minstEnPart && infotrygdGrunnlag.minstEnPart -> throw IllegalStateException(
-                "Berører parter som finnes både i K9Sak og Infotrygd. K9Sak=[$k9SakGrunnlag], Infotrygd=[$infotrygdGrunnlag]"
-            )
+            k9SakGrunnlag.minstEnPart && infotrygdGrunnlag.minstEnPart -> logger.warn(
+                "Berører parter som finnes både i Infotrygd og K9Sak. Infotrygd=[$infotrygdGrunnlag], K9Sak=[$k9SakGrunnlag]"
+            ).let { Destinasjon.K9Sak }
             infotrygdGrunnlag.minstEnPart -> Destinasjon.Infotrygd
             else -> Destinasjon.K9Sak
         }
@@ -48,6 +49,10 @@ internal class RutingService(
     internal enum class Destinasjon {
         K9Sak,
         Infotrygd
+    }
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(RutingService::class.java)
     }
 }
 

--- a/app/src/main/kotlin/no/nav/punsjbolle/ruting/RutingService.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/ruting/RutingService.kt
@@ -29,6 +29,11 @@ internal class RutingService(
             correlationId = correlationId
         )
 
+        if (k9SakGrunnlag.minstEnPart) {
+            logger.info("Rutes til K9Sak ettersom minst en part er involvert i løpende sak. K9Sak=[$k9SakGrunnlag]")
+            return Destinasjon.K9Sak
+        }
+
         val infotrygdGrunnlag = infotrygdClient.harLøpendeSakSomInvolvererEnAv(
             søker = søker,
             fraOgMed = fraOgMed,
@@ -38,11 +43,12 @@ internal class RutingService(
         )
 
         return when {
-            k9SakGrunnlag.minstEnPart && infotrygdGrunnlag.minstEnPart -> logger.warn(
-                "Berører parter som finnes både i Infotrygd og K9Sak. Infotrygd=[$infotrygdGrunnlag], K9Sak=[$k9SakGrunnlag]"
-            ).let { Destinasjon.K9Sak }
-            infotrygdGrunnlag.minstEnPart -> Destinasjon.Infotrygd
-            else -> Destinasjon.K9Sak
+            infotrygdGrunnlag.minstEnPart -> Destinasjon.Infotrygd.also {
+                logger.info("Rutes til Infotrygd ettersom minst en part er involvert i en løpende sak. Infotrygd=[$infotrygdGrunnlag]")
+            }
+            else -> Destinasjon.K9Sak.also {
+                logger.info("Rutes til K9Sak ettersom ingen parter er involvert hverken i Infotrygd eller K9Sak fra før")
+            }
         }
     }
 

--- a/app/src/main/kotlin/no/nav/punsjbolle/sak/SakClient.kt
+++ b/app/src/main/kotlin/no/nav/punsjbolle/sak/SakClient.kt
@@ -1,0 +1,63 @@
+package no.nav.punsjbolle.sak
+
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.httpPost
+import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.jsonBody
+import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.readTextOrThrow
+import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
+import no.nav.punsjbolle.AktørId
+import no.nav.punsjbolle.AzureAwareClient
+import no.nav.punsjbolle.CorrelationId
+import no.nav.punsjbolle.K9Saksnummer
+import org.intellij.lang.annotations.Language
+import org.slf4j.LoggerFactory
+import java.net.URI
+
+internal class SakClient(
+    baseUrl: URI,
+    accessTokenClient: AccessTokenClient,
+    scopes: Set<String>
+) : AzureAwareClient(
+    navn = "SakClient",
+    accessTokenClient = accessTokenClient,
+    scopes = scopes,
+    pingUrl = URI("$baseUrl/internal/ready")) {
+
+    private val OpprettSakUrl = URI("$baseUrl/api/v1/saker")
+
+    internal suspend fun forsikreSakskoblingFinnes(
+        saksnummer: K9Saksnummer,
+        søker: AktørId,
+        correlationId: CorrelationId) {
+
+        @Language("JSON")
+        val dto = """
+            {
+              "tema": "OMS",
+              "applikasjon": "K9",
+              "aktoerId": "$søker",
+              "fagsakNr": "$saksnummer"
+            }
+        """.trimIndent()
+
+        val (httpStatusCode, response) = OpprettSakUrl.httpPost {
+            it.header(HttpHeaders.Authorization, authorizationHeader())
+            it.header(HttpHeaders.XCorrelationId, "$correlationId")
+            it.accept(ContentType.Application.Json)
+            it.jsonBody(dto)
+        }.readTextOrThrow()
+
+        when (httpStatusCode) {
+            HttpStatusCode.Created -> logger.info("Opprettet sakskobling.")
+            HttpStatusCode.Conflict -> logger.info("Sakskobling finnes allerede.")
+            else -> throw IllegalStateException(
+                "Feil fra Sak. URL=[$OpprettSakUrl], HttpStatusCode=[${httpStatusCode.value}], Response=[$response]"
+            )
+        }
+    }
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(SakClient::class.java)
+    }
+}

--- a/app/src/test/kotlin/no/nav/punsjbolle/api/SaksnummerApiTest.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/api/SaksnummerApiTest.kt
@@ -1,0 +1,186 @@
+package no.nav.punsjbolle.api
+
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import io.mockk.*
+import no.nav.punsjbolle.AktørId.Companion.somAktørId
+import no.nav.punsjbolle.ApplicationContext
+import no.nav.punsjbolle.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.punsjbolle.JournalpostId
+import no.nav.punsjbolle.JournalpostId.Companion.somJournalpostId
+import no.nav.punsjbolle.K9Saksnummer.Companion.somK9Saksnummer
+import no.nav.punsjbolle.infotrygd.InfotrygdClient
+import no.nav.punsjbolle.joark.Journalpost
+import no.nav.punsjbolle.joark.SafClient
+import no.nav.punsjbolle.k9sak.K9SakClient
+import no.nav.punsjbolle.punsjbolle
+import no.nav.punsjbolle.ruting.RutingGrunnlag
+import no.nav.punsjbolle.testutils.ApplicationContextExtension
+import org.intellij.lang.annotations.Language
+import org.json.JSONObject
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDate
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@ExtendWith(ApplicationContextExtension::class)
+internal class SaksnummerApiTest(
+    builder: ApplicationContext.Builder) {
+
+    private val safClientMock : SafClient = mockk()
+    private val k9SakClientMock : K9SakClient = mockk()
+    private val infotrygdClientMock : InfotrygdClient = mockk()
+
+    private val applicationContext = builder.also { builder ->
+        builder.safClient = safClientMock
+        builder.k9SakClient = k9SakClientMock
+        builder.infotrygdClient = infotrygdClientMock
+    }.build()
+
+
+    @BeforeEach
+    fun beforeEach() {
+        clearMocks(safClientMock, k9SakClientMock, infotrygdClientMock)
+    }
+
+    @Test
+    fun `ingen saker i hverken Infotrygd eller K9sak med journalpostId`() {
+        mockInfotrygd()
+        mockK9Sak()
+        mockHentSaksnummer()
+        mockHentJournalpost()
+
+        val (httpStatus, k9Saksnummer) = request(journalpostId = journalpostId, fraOgMed = null)
+        assertEquals(HttpStatusCode.OK, httpStatus)
+        assertEquals(saksnummer, k9Saksnummer)
+        verifiserSafKalt()
+    }
+
+    @Test
+    fun `ingen saker i hverken Infotrygd eller K9sak med fraOgMed`() {
+        mockInfotrygd()
+        mockK9Sak()
+        mockHentSaksnummer()
+
+        val (httpStatus, k9Saksnummer) = request(journalpostId = null, fraOgMed = LocalDate.now())
+        assertEquals(HttpStatusCode.OK, httpStatus)
+        assertEquals(saksnummer, k9Saksnummer)
+        verifiserSafIkkeKalt()
+    }
+
+    @Test
+    fun `søker har sak i infotrygd, ingenting i K9Sak`() {
+        mockInfotrygd(søker = true)
+        mockK9Sak()
+        mockHentJournalpost()
+
+        val (httpStatus, k9Saksnummer) = request(journalpostId = journalpostId, fraOgMed = null)
+        assertEquals(HttpStatusCode.Conflict, httpStatus)
+        assertNull(k9Saksnummer)
+        verifiserSafKalt()
+        verifiserSaksnummerIkkeOpprettet()
+    }
+
+    @Test
+    fun `pleietrengende har vedtak i Infotrygd, ingenting i K9Sak`() {
+        mockInfotrygd(pleietrengende = true)
+        mockK9Sak()
+        mockHentJournalpost()
+
+        val (httpStatus, k9Saksnummer) = request(journalpostId = journalpostId, fraOgMed = null)
+        assertEquals(HttpStatusCode.Conflict, httpStatus)
+        assertNull(k9Saksnummer)
+        verifiserSafKalt()
+        verifiserSaksnummerIkkeOpprettet()
+    }
+
+    @Test
+    fun `søker har sak i K9Sak, pleietrengende i Infotrygd`() {
+        mockInfotrygd(pleietrengende = true)
+        mockK9Sak(søker = true)
+        mockHentSaksnummer()
+
+        val (httpStatus, k9Saksnummer) = request(journalpostId = null, fraOgMed = LocalDate.now())
+        assertEquals(HttpStatusCode.OK, httpStatus)
+        assertEquals(saksnummer, k9Saksnummer)
+        verifiserSafIkkeKalt()
+    }
+
+    private fun request(fraOgMed: LocalDate?, journalpostId: JournalpostId?) = withTestApplication( { punsjbolle(applicationContext)}) {
+        handleRequest(HttpMethod.Post, "/api/saksnummer") {
+            addHeader(HttpHeaders.XCorrelationId, "${UUID.randomUUID()}")
+            addHeader(HttpHeaders.ContentType, "application/json; charset=UTF-8")
+            setBody(requestBody(fraOgMed = fraOgMed, journalpostId = journalpostId))
+        }.let {
+            it.response.status()!! to it.response.content?.let { json -> JSONObject(json).getString("saksnummer").somK9Saksnummer() }
+        }
+    }
+
+    private fun verifiserSafIkkeKalt() =
+        coVerify { safClientMock.hentJournalpost(any(), any()) wasNot Called }
+
+    private fun verifiserSafKalt() =
+        coVerify(exactly = 1) { safClientMock.hentJournalpost(any(), any()) }
+
+    private fun verifiserSaksnummerIkkeOpprettet() =
+        coVerify { k9SakClientMock.hentSaksnummer(any(), any()) wasNot Called }
+
+    private fun mockInfotrygd(søker: Boolean = false, pleietrengende: Boolean = false, annenPart: Boolean = false) {
+        coEvery { infotrygdClientMock.harLøpendeSakSomInvolvererEnAv(any(),any(), any(), any(), any()) }.returns(
+            RutingGrunnlag(søker = søker, pleietrengende = pleietrengende, annenPart = annenPart)
+        )
+    }
+
+    private fun mockK9Sak(søker: Boolean = false, pleietrengende: Boolean = false, annenPart: Boolean = false) {
+        coEvery { k9SakClientMock.harLøpendeSakSomInvolvererEnAv(any(),any(), any(), any(), any(), any()) }.returns(
+            RutingGrunnlag(søker = søker, pleietrengende = pleietrengende, annenPart = annenPart)
+        )
+    }
+
+    private fun mockHentSaksnummer() {
+        coEvery { k9SakClientMock.hentSaksnummer(any(),any()) }.returns(saksnummer)
+    }
+
+    private fun mockHentJournalpost() {
+        coEvery { safClientMock.hentJournalpost(any(), any()) }.returns(Journalpost(
+            journalpostId = journalpostId,
+            journalposttype = "foo",
+            journalpoststatus = "bar",
+            opprettet = opprettet.atStartOfDay(),
+            eksternReferanse = null,
+            brevkode = null,
+            sak = null
+        ))
+    }
+
+
+    private companion object {
+        private val opprettet = LocalDate.parse("2021-01-01")
+        private val saksnummer = "SAK123".somK9Saksnummer()
+        private val søkerIdentitetsnummer = "11111111111".somIdentitetsnummer()
+        private val søkerAktørId = "22222222222".somAktørId()
+        private val pleietrengendeIdentitetsnummer = "33333333333".somIdentitetsnummer()
+        private val pleietrengendeAktørId = "44444444444".somAktørId()
+        private val journalpostId = "55555555555".somJournalpostId()
+
+        @Language("JSON")
+        private fun requestBody(fraOgMed: LocalDate?, journalpostId: JournalpostId?) = """
+            {
+              "søker": {
+                "identitetsnummer": "$søkerIdentitetsnummer",
+                "aktørId": "$søkerAktørId"
+              },
+              "pleietrengende": {
+                "identitetsnummer": "$pleietrengendeIdentitetsnummer",
+                "aktørId": "$pleietrengendeAktørId"
+              },
+              "søknadstype": "PleiepengerSyktBarn",
+              "journalpostId": ${journalpostId?.let { """"$it"""" }},
+              "fraOgMed": ${fraOgMed?.let { """"$it"""" }}
+            }
+        """.trimIndent()
+    }
+}

--- a/app/src/test/kotlin/no/nav/punsjbolle/api/SaksnummerApiTest.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/api/SaksnummerApiTest.kt
@@ -146,7 +146,7 @@ internal class SaksnummerApiTest(
         )) = withTestApplication( { punsjbolle(applicationContext)}) {
         handleRequest(HttpMethod.Post, "/api/saksnummer") {
             addHeader(HttpHeaders.XCorrelationId, "${UUID.randomUUID()}")
-            addHeader(HttpHeaders.ContentType, "application/json; charset=UTF-8")
+            addHeader(HttpHeaders.ContentType, "application/json")
             jwt?.let { addHeader(HttpHeaders.Authorization, "Bearer $it") }
             setBody(requestBody(fraOgMed = fraOgMed, journalpostId = journalpostId))
         }.let {

--- a/app/src/test/kotlin/no/nav/punsjbolle/testutils/ApplicationContextExtension.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/testutils/ApplicationContextExtension.kt
@@ -1,6 +1,8 @@
 package no.nav.punsjbolle.testutils
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import no.nav.helse.dusseldorf.testsupport.jws.Azure
+import no.nav.helse.dusseldorf.testsupport.wiremock.getAzureV2JwksUrl
 import no.nav.helse.dusseldorf.testsupport.wiremock.getAzureV2TokenUrl
 import no.nav.punsjbolle.ApplicationContext
 import no.nav.punsjbolle.testutils.wiremock.infotrygdGrunnlagPaaroerendeSykdomBaseUrl
@@ -19,6 +21,8 @@ internal class ApplicationContextExtension : ParameterResolver {
             "AZURE_APP_CLIENT_ID" to "k9-punsjbolle",
             "AZURE_APP_CLIENT_SECRET" to "foo",
             "AZURE_OPENID_CONFIG_TOKEN_ENDPOINT" to mockedEnvironment.wireMockServer.getAzureV2TokenUrl(),
+            "AZURE_OPENID_CONFIG_ISSUER" to Azure.V2_0.getIssuer(),
+            "AZURE_OPENID_CONFIG_JWKS_URI" to mockedEnvironment.wireMockServer.getAzureV2JwksUrl(),
             "K9_SAK_BASE_URL" to mockedEnvironment.wireMockServer.k9SakBaseUrl(),
             "K9_SAK_SCOPES" to "k9-sak/.default",
             "SAF_BASE_URL" to mockedEnvironment.wireMockServer.safBaseUrl(),

--- a/app/src/test/kotlin/no/nav/punsjbolle/testutils/ApplicationContextExtension.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/testutils/ApplicationContextExtension.kt
@@ -8,6 +8,7 @@ import no.nav.punsjbolle.ApplicationContext
 import no.nav.punsjbolle.testutils.wiremock.infotrygdGrunnlagPaaroerendeSykdomBaseUrl
 import no.nav.punsjbolle.testutils.wiremock.k9SakBaseUrl
 import no.nav.punsjbolle.testutils.wiremock.safBaseUrl
+import no.nav.punsjbolle.testutils.wiremock.sakBaseUrl
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
 import org.junit.jupiter.api.extension.ParameterResolver
@@ -25,6 +26,8 @@ internal class ApplicationContextExtension : ParameterResolver {
             "AZURE_OPENID_CONFIG_JWKS_URI" to mockedEnvironment.wireMockServer.getAzureV2JwksUrl(),
             "K9_SAK_BASE_URL" to mockedEnvironment.wireMockServer.k9SakBaseUrl(),
             "K9_SAK_SCOPES" to "k9-sak/.default",
+            "SAK_BASE_URL" to mockedEnvironment.wireMockServer.sakBaseUrl(),
+            "SAK_SCOPES" to "sak/.default",
             "SAF_BASE_URL" to mockedEnvironment.wireMockServer.safBaseUrl(),
             "SAF_SCOPES" to "saf/.default",
             "INFOTRYGD_GRUNNLAG_PAAROERENDE_SYKDOM_BASE_URL" to mockedEnvironment.wireMockServer.infotrygdGrunnlagPaaroerendeSykdomBaseUrl(),

--- a/app/src/test/kotlin/no/nav/punsjbolle/testutils/MockedEnvironment.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/testutils/MockedEnvironment.kt
@@ -4,6 +4,7 @@ import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
 import no.nav.punsjbolle.testutils.wiremock.mockInfotrygdGrunnlagPaaroerendeSykdom
 import no.nav.punsjbolle.testutils.wiremock.mockK9Sak
 import no.nav.punsjbolle.testutils.wiremock.mockSaf
+import no.nav.punsjbolle.testutils.wiremock.mockSak
 
 internal class MockedEnvironment {
     internal val wireMockServer = WireMockBuilder()
@@ -11,6 +12,7 @@ internal class MockedEnvironment {
         .withNaisStsSupport()
         .build()
         .mockK9Sak()
+        .mockSak()
         .mockSaf()
         .mockInfotrygdGrunnlagPaaroerendeSykdom()
 

--- a/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/InfotrygdGrunnlagPaaroerendeSykdomMock.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/InfotrygdGrunnlagPaaroerendeSykdomMock.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.matching.AnythingPattern
 import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withAuthorizationHeader
-import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withDefaultGetHeaders
+import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withNavGetHeaders
 import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withJson
 
 private const val path = "/infotrygd-grunnlag-paaroerende-sykdom-mock"
@@ -19,7 +19,7 @@ private fun WireMockServer.mockPingUrl(): WireMockServer {
 private fun WireMockServer.mockSaker(): WireMockServer {
     WireMock.stubFor(
         WireMock.get(WireMock.urlPathMatching(".*$path/saker.*"))
-            .withDefaultGetHeaders().withQueryParam("fnr", AnythingPattern()).withQueryParam("fom", AnythingPattern())
+            .withNavGetHeaders().withQueryParam("fnr", AnythingPattern()).withQueryParam("fom", AnythingPattern())
             .willReturn(WireMock.aResponse().withJson("""{"saker":[], "vedtak":[]}""")))
     return this
 }
@@ -27,7 +27,7 @@ private fun WireMockServer.mockSaker(): WireMockServer {
 private fun WireMockServer.mockVedtakForPleietrengende(): WireMockServer {
     WireMock.stubFor(
         WireMock.get(WireMock.urlPathMatching(".*$path/vedtakForPleietrengende.*"))
-            .withDefaultGetHeaders().withQueryParam("fnr", AnythingPattern()).withQueryParam("fom", AnythingPattern())
+            .withNavGetHeaders().withQueryParam("fnr", AnythingPattern()).withQueryParam("fom", AnythingPattern())
             .willReturn(WireMock.aResponse().withJson("""[{"vedtak":[]}]""")))
     return this
 }

--- a/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/K9SakMock.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/K9SakMock.kt
@@ -3,7 +3,7 @@ package no.nav.punsjbolle.testutils.wiremock
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withAuthorizationHeader
-import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withDefaultPostHeaders
+import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withNavPostHeaders
 import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withJson
 
 private const val path = "/k9-sak-mock"
@@ -18,7 +18,7 @@ private fun WireMockServer.mockPingUrl(): WireMockServer {
 private fun WireMockServer.mockHentSaksnummer(): WireMockServer {
     WireMock.stubFor(
         WireMock.post(WireMock.urlPathMatching(".*$path/api/fordel/fagsak/opprett"))
-            .withDefaultPostHeaders()
+            .withNavPostHeaders()
             .withRequestBody(WireMock.matchingJsonPath("$.ytelseType"))
             .withRequestBody(WireMock.matchingJsonPath("$.aktørId"))
             .withRequestBody(WireMock.matchingJsonPath("$.pleietrengendeAktørId"))
@@ -30,7 +30,7 @@ private fun WireMockServer.mockHentSaksnummer(): WireMockServer {
 private fun WireMockServer.mockSendInnSøknad(): WireMockServer {
     WireMock.stubFor(
         WireMock.post(WireMock.urlPathMatching(".*$path/api/fordel/journalposter"))
-            .withDefaultPostHeaders()
+            .withNavPostHeaders()
             .withRequestBody(WireMock.matchingJsonPath("$.[0].saksnummer"))
             .withRequestBody(WireMock.matchingJsonPath("$.[0].journalpostId"))
             .withRequestBody(WireMock.matchingJsonPath("$.[0].ytelseType.kode"))
@@ -47,7 +47,7 @@ private fun WireMockServer.mockSendInnSøknad(): WireMockServer {
 private fun WireMockServer.mockMatchFagsak(): WireMockServer {
     WireMock.stubFor(
         WireMock.post(WireMock.urlPathMatching(".*$path/api/fagsak/match"))
-            .withDefaultPostHeaders()
+            .withNavPostHeaders()
             .withRequestBody(WireMock.matchingJsonPath("$.ytelseType.kode"))
             .withRequestBody(WireMock.matchingJsonPath("$.ytelseType.kodeverk", WireMock.equalTo("FAGSAK_YTELSE")))
             .withRequestBody(WireMock.matchingJsonPath("$.periode.fom"))

--- a/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/SafMock.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/SafMock.kt
@@ -3,7 +3,7 @@ package no.nav.punsjbolle.testutils.wiremock
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withAuthorizationHeader
-import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withDefaultPostHeaders
+import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withNavPostHeaders
 import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withJson
 import org.intellij.lang.annotations.Language
 
@@ -33,7 +33,7 @@ private fun WireMockServer.mockPingUrl(): WireMockServer {
 
 private fun WireMockServer.mockHentJournalpost(): WireMockServer {
     WireMock.stubFor(
-        WireMock.post(WireMock.urlPathMatching(".*$path/graphql")).withDefaultPostHeaders()
+        WireMock.post(WireMock.urlPathMatching(".*$path/graphql")).withNavPostHeaders()
             .willReturn(WireMock.aResponse().withJson(hentJounralpostResponse))
     )
     return this

--- a/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/SakMock.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/SakMock.kt
@@ -1,0 +1,34 @@
+package no.nav.punsjbolle.testutils.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withAuthorizationHeader
+import no.nav.punsjbolle.testutils.wiremock.WireMockVerktøy.withDefaultPostHeaders
+
+private const val path = "/sak-mock"
+
+private fun WireMockServer.mockPingUrl(): WireMockServer {
+    WireMock.stubFor(
+        WireMock.get(WireMock.urlPathMatching(".*$path/internal/ready")).withAuthorizationHeader()
+            .willReturn(WireMock.aResponse().withStatus(200)))
+    return this
+}
+
+private fun WireMockServer.mockOpprettSak(): WireMockServer {
+    WireMock.stubFor(
+        WireMock.post(WireMock.urlPathMatching(".*$path/api/v1/saker"))
+            .withDefaultPostHeaders()
+            .withRequestBody(WireMock.matchingJsonPath("$.tema",WireMock.equalTo("OMS")))
+            .withRequestBody(WireMock.matchingJsonPath("$.applikasjon", WireMock.equalTo("K9")))
+            .withRequestBody(WireMock.matchingJsonPath("$.aktoerId"))
+            .withRequestBody(WireMock.matchingJsonPath("$.fagsakNr"))
+            .willReturn(WireMock.aResponse().withStatus(when ((0..1).random()) {
+                0 -> 201
+                else -> 409
+            })))
+    return this
+}
+
+
+internal fun WireMockServer.mockSak() = mockPingUrl().mockOpprettSak()
+internal fun WireMockServer.sakBaseUrl() = baseUrl() + path

--- a/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/WireMockVerktøy.kt
+++ b/app/src/test/kotlin/no/nav/punsjbolle/testutils/wiremock/WireMockVerktøy.kt
@@ -9,15 +9,21 @@ internal object WireMockVerktøy {
     internal fun MappingBuilder.withAuthorizationHeader() =
         withHeader("Authorization", WireMock.containing("Bearer e"))
 
-    internal fun MappingBuilder.withDefaultGetHeaders() =
+    internal fun MappingBuilder.withNavGetHeaders() =
         withAuthorizationHeader()
         .withHeader("Accept", WireMock.equalTo("application/json"))
         .withHeader("Nav-Consumer-Id", WireMock.equalTo("k9-punsjbolle"))
         .withHeader("Nav-Callid", AnythingPattern())
 
-    internal fun MappingBuilder.withDefaultPostHeaders() =
-        withDefaultGetHeaders()
+    internal fun MappingBuilder.withNavPostHeaders() =
+        withNavGetHeaders()
         .withHeader("Content-Type", WireMock.equalTo("application/json"))
+
+    internal fun MappingBuilder.withDefaultPostHeaders() =
+        withAuthorizationHeader()
+        .withHeader("Accept", WireMock.equalTo("application/json"))
+        .withHeader("Content-Type", WireMock.equalTo("application/json"))
+        .withHeader("X-Correlation-ID", AnythingPattern())
 
     internal fun ResponseDefinitionBuilder.withJson(json: String) =
         withHeader("Content-Type", "application/json")

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -16,6 +16,8 @@
     "SAF_SCOPES": "824525c6-74df-47fc-8892-444e5f8506de/.default",
     "K9_SAK_BASE_URL": "https://omsorgspenger-proxy.dev-fss-pub.nais.io/k9-sak",
     "K9_SAK_SCOPES": "824525c6-74df-47fc-8892-444e5f8506de/.default",
+    "SAK_BASE_URL": "https://omsorgspenger-proxy.dev-fss-pub.nais.io/sak",
+    "SAK_SCOPES": "824525c6-74df-47fc-8892-444e5f8506de/.default",
     "INFOTRYGD_GRUNNLAG_PAAROERENDE_SYKDOM_BASE_URL": "https://omsorgspenger-proxy.dev-fss-pub.nais.io/infotrygd-grunnlag-paaroerende-sykdom",
     "INFOTRYGD_GRUNNLAG_PAAROERENDE_SYKDOM_SCOPES": "32551525-c4dd-44ae-b906-2f8d8a00bb03/.default"
   }

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -1,5 +1,6 @@
 {
   "cluster": "dev-gcp",
+  "clusterFss": "dev-fss",
   "minReplicas": "2",
   "maxReplicas": "4",
   "azureTenant": "trygdeetaten.no",

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -20,6 +20,11 @@ spec:
       {{#each externalHosts as |host|}}
          - host: {{host}}
       {{/each}}
+    inbound:
+      rules:
+        - application: k9-punsj
+          namespace: k9saksbehandling
+          cluster: {{clusterFss}}
   liveness:
     path: isalive
     initialDelay: 20

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -1,5 +1,6 @@
 {
   "cluster": "prod-gcp",
+  "clusterFss": "prod-fss",
   "minReplicas": "2",
   "maxReplicas": "4",
   "azureTenant": "nav.no",

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -16,6 +16,8 @@
     "SAF_SCOPES": "e816bb42-bf62-4be9-a1cc-a9be70fe4403/.default",
     "K9_SAK_BASE_URL": "https://omsorgspenger-proxy.prod-fss-pub.nais.io/k9-sak",
     "K9_SAK_SCOPES": "e816bb42-bf62-4be9-a1cc-a9be70fe4403/.default",
+    "SAK_BASE_URL": "https://omsorgspenger-proxy.prod-fss-pub.nais.io/sak",
+    "SAK_SCOPES": "e816bb42-bf62-4be9-a1cc-a9be70fe4403/.default",
     "INFOTRYGD_GRUNNLAG_PAAROERENDE_SYKDOM_BASE_URL": "https://omsorgspenger-proxy.prod-fss-pub.nais.io/infotrygd-grunnlag-paaroerende-sykdom",
     "INFOTRYGD_GRUNNLAG_PAAROERENDE_SYKDOM_SCOPES": "fadafa61-0d49-43d4-b256-8a589b215da5/.default"
   }


### PR DESCRIPTION
- API for å hente saksnummer
- Om vi finner sak med involverte parter både i Infotrygd & K9Sak setter vi nå destinasjon K9Sak istedenfor å feile.
- Fjerner logging av response fra K9Sak om vi finner matchende fagsak.